### PR TITLE
Background app notification: disable by default [2/2]

### DIFF
--- a/core/java/com/android/internal/notification/SystemNotificationChannels.java
+++ b/core/java/com/android/internal/notification/SystemNotificationChannels.java
@@ -135,7 +135,7 @@ public class SystemNotificationChannels {
         channelsList.add(new NotificationChannel(
                 FOREGROUND_SERVICE,
                 context.getString(R.string.notification_channel_foreground_service),
-                NotificationManager.IMPORTANCE_LOW));
+                NotificationManager.IMPORTANCE_NONE));
 
         nm.createNotificationChannels(channelsList);
     }


### PR DESCRIPTION
it can be enabled again with this commit (that's 1/2 part):
https://github.com/ezio84/abc_packages_apps_Settings/commit/b9bd0b52ee586f787e994bfdfec0749ceca06791