### PR TITLE
Display network name in status bar(1/2)

### DIFF
--- a/packages/SystemUI/res/layout/operator_name.xml
+++ b/packages/SystemUI/res/layout/operator_name.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2017 The Android Open Source Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<com.android.systemui.statusbar.AlphaOptimizedFrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/operator_name_frame"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    >
+    <com.android.systemui.statusbar.OperatorNameView
+        android:id="@+id/operator_name"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:maxLength="20"
+        android:gravity="center_vertical|start"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:singleLine="true" />
+</com.android.systemui.statusbar.AlphaOptimizedFrameLayout>

--- a/packages/SystemUI/res/layout/status_bar.xml
+++ b/packages/SystemUI/res/layout/status_bar.xml
@@ -48,6 +48,11 @@
         android:paddingEnd="8dp"
         android:orientation="horizontal"
         >
+        <ViewStub
+            android:id="@+id/operator_name"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout="@layout/operator_name" />
 
         <!-- The alpha of this area is controlled from both PhoneStatusBarTransitions and
              PhoneStatusBar (DISABLE_NOTIFICATION_ICONS). -->

--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -336,4 +336,7 @@
     <!-- Whether to show activity indicators in the status bar -->
     <bool name="config_showActivity">false</bool>
 
+    <!-- Whether to show operator name in the status bar -->
+    <bool name="config_showOperatorNameInStatusBar">false</bool>
+
 </resources>

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardUpdateMonitor.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardUpdateMonitor.java
@@ -1747,6 +1747,10 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener {
         }
     }
 
+    public ServiceState getServiceState(int subId) {
+        return mServiceStates.get(subId);
+    }
+
     /**
      * @return true if and only if the state has changed for the specified {@code slotId}
      */

--- a/packages/SystemUI/src/com/android/systemui/DemoMode.java
+++ b/packages/SystemUI/src/com/android/systemui/DemoMode.java
@@ -37,4 +37,5 @@ public interface DemoMode {
     public static final String COMMAND_STATUS = "status";
     public static final String COMMAND_NOTIFICATIONS = "notifications";
     public static final String COMMAND_VOLUME = "volume";
+    public static final String COMMAND_OPERATOR = "operator";
 }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/OperatorNameView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/OperatorNameView.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.android.systemui.statusbar;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.graphics.Rect;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.telephony.ServiceState;
+import android.telephony.SubscriptionInfo;
+import android.text.TextUtils;
+import android.util.AttributeSet;
+import android.widget.TextView;
+
+import com.android.internal.telephony.IccCardConstants.State;
+import com.android.keyguard.KeyguardUpdateMonitor;
+import com.android.keyguard.KeyguardUpdateMonitorCallback;
+import com.android.settingslib.WirelessUtils;
+import com.android.systemui.DemoMode;
+import com.android.systemui.Dependency;
+import com.android.systemui.statusbar.policy.DarkIconDispatcher;
+import com.android.systemui.statusbar.policy.DarkIconDispatcher.DarkReceiver;
+import com.android.systemui.statusbar.policy.NetworkController;
+import com.android.systemui.statusbar.policy.NetworkController.IconState;
+import com.android.systemui.statusbar.policy.NetworkController.SignalCallback;
+import com.android.systemui.tuner.TunerService;
+import com.android.systemui.tuner.TunerService.Tunable;
+
+import java.util.List;
+
+public class OperatorNameView extends TextView implements DemoMode, DarkReceiver,
+        SignalCallback, Tunable {
+
+    private static final String KEY_SHOW_OPERATOR_NAME = "show_operator_name";
+
+    private KeyguardUpdateMonitor mKeyguardUpdateMonitor;
+    private boolean mDemoMode;
+
+    private final KeyguardUpdateMonitorCallback mCallback = new KeyguardUpdateMonitorCallback() {
+        @Override
+        public void onRefreshCarrierInfo() {
+            updateText();
+        }
+    };
+
+    public OperatorNameView(Context context) {
+        this(context, null);
+    }
+
+    public OperatorNameView(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public OperatorNameView(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        mKeyguardUpdateMonitor = KeyguardUpdateMonitor.getInstance(mContext);
+        mKeyguardUpdateMonitor.registerCallback(mCallback);
+        Dependency.get(DarkIconDispatcher.class).addDarkReceiver(this);
+        Dependency.get(NetworkController.class).addCallback(this);
+        Dependency.get(TunerService.class).addTunable(this, KEY_SHOW_OPERATOR_NAME);
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        mKeyguardUpdateMonitor.removeCallback(mCallback);
+        Dependency.get(DarkIconDispatcher.class).removeDarkReceiver(this);
+        Dependency.get(NetworkController.class).removeCallback(this);
+        Dependency.get(TunerService.class).removeTunable(this);
+    }
+
+    @Override
+    public void onDarkChanged(Rect area, float darkIntensity, int tint) {
+        setTextColor(DarkIconDispatcher.getTint(area, this, tint));
+    }
+
+    @Override
+    public void setIsAirplaneMode(IconState icon) {
+        update();
+    }
+
+    @Override
+    public void onTuningChanged(String key, String newValue) {
+        update();
+    }
+
+    @Override
+    public void dispatchDemoCommand(String command, Bundle args) {
+        if (!mDemoMode && command.equals(COMMAND_ENTER)) {
+            mDemoMode = true;
+        } else if (mDemoMode && command.equals(COMMAND_EXIT)) {
+            mDemoMode = false;
+            update();
+        } else if (mDemoMode && command.equals(COMMAND_OPERATOR)) {
+            setText(args.getString("name"));
+        }
+    }
+
+    private void update() {
+        boolean showOperatorName = Dependency.get(TunerService.class)
+                .getValue(KEY_SHOW_OPERATOR_NAME, 1) != 0;
+        setVisibility(showOperatorName ? VISIBLE : GONE);
+
+        boolean hasMobile = ConnectivityManager.from(mContext)
+                .isNetworkSupported(ConnectivityManager.TYPE_MOBILE);
+        boolean airplaneMode = WirelessUtils.isAirplaneModeOn(mContext);
+        if (!hasMobile || airplaneMode) {
+            setText(null);
+            setVisibility(GONE);
+            return;
+        }
+
+        if (!mDemoMode) {
+            updateText();
+        }
+    }
+
+    private void updateText() {
+        CharSequence displayText = null;
+        List<SubscriptionInfo> subs = mKeyguardUpdateMonitor.getSubscriptionInfo(false);
+        final int N = subs.size();
+        for (int i = 0; i < N; i++) {
+            int subId = subs.get(i).getSubscriptionId();
+            State simState = mKeyguardUpdateMonitor.getSimState(subId);
+            CharSequence carrierName = subs.get(i).getCarrierName();
+            if (!TextUtils.isEmpty(carrierName) && simState == State.READY) {
+                ServiceState ss = mKeyguardUpdateMonitor.getServiceState(subId);
+                if (ss != null && ss.getState() == ServiceState.STATE_IN_SERVICE) {
+                    displayText = carrierName;
+                    break;
+                }
+            }
+        }
+
+        setText(displayText);
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/CollapsedStatusBarFragment.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/CollapsedStatusBarFragment.java
@@ -57,6 +57,7 @@ public class CollapsedStatusBarFragment extends Fragment implements CommandQueue
     private StatusBar mStatusBarComponent;
     private DarkIconManager mDarkIconManager;
     private SignalClusterView mSignalClusterView;
+    private View mOperatorNameFrame;
 
     private SignalCallback mSignalCallback = new SignalCallback() {
         @Override
@@ -94,6 +95,7 @@ public class CollapsedStatusBarFragment extends Fragment implements CommandQueue
         // Default to showing until we know otherwise.
         showSystemIconArea(false);
         initEmergencyCryptkeeperText();
+        initOperatorName();
     }
 
     @Override
@@ -147,8 +149,10 @@ public class CollapsedStatusBarFragment extends Fragment implements CommandQueue
         if ((diff1 & StatusBarManager.DISABLE_SYSTEM_INFO) != 0) {
             if ((state1 & StatusBarManager.DISABLE_SYSTEM_INFO) != 0) {
                 hideSystemIconArea(animate);
+                hideOperatorName(animate);
             } else {
                 showSystemIconArea(animate);
+                showOperatorName(animate);
             }
         }
         if ((diff1 & StatusBarManager.DISABLE_NOTIFICATION_ICONS) != 0) {
@@ -196,6 +200,18 @@ public class CollapsedStatusBarFragment extends Fragment implements CommandQueue
 
     public void showNotificationIconArea(boolean animate) {
         animateShow(mNotificationIconAreaInner, animate);
+    }
+
+    public void hideOperatorName(boolean animate) {
+        if (mOperatorNameFrame != null) {
+            animateHide(mOperatorNameFrame, animate);
+        }
+    }
+
+    public void showOperatorName(boolean animate) {
+        if (mOperatorNameFrame != null) {
+            animateShow(mOperatorNameFrame, animate);
+        }
     }
 
     /**
@@ -257,6 +273,13 @@ public class CollapsedStatusBarFragment extends Fragment implements CommandQueue
         } else if (emergencyViewStub != null) {
             ViewGroup parent = (ViewGroup) emergencyViewStub.getParent();
             parent.removeView(emergencyViewStub);
+        }
+    }
+
+    private void initOperatorName() {
+        if (getResources().getBoolean(R.bool.config_showOperatorNameInStatusBar)) {
+            ViewStub stub = mStatusBar.findViewById(R.id.operator_name);
+            mOperatorNameFrame = stub.inflate();
         }
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
@@ -4082,6 +4082,9 @@ public class StatusBar extends SystemUI implements DemoMode,
                 }
             }
         }
+        if (modeChange || command.equals(COMMAND_OPERATOR)) {
+            dispatchDemoCommandToView(command, args, R.id.operator_name);
+        }
     }
 
     private void dispatchDemoCommandToView(String command, Bundle args, int id) {


### PR DESCRIPTION
When config_showOperatorNameInStatusBar is true, the network name is
displayed in the status bar.
The user can turn on/off the feature from Settings app (Settings >
Display > Network name).

Fixes: 67620513
Test: manual - insert a valid SIM and go to the Home screen.

Change-Id: I6d03ec00a19e2f5e4c2d2918f1a7c33fdee00dd2