### PR TITLE
Add an option to force pre-O apps to use full screen aspect ratio

### DIFF
--- a/core/res/res/values/candy_config.xml
+++ b/core/res/res/values/candy_config.xml
@@ -1,0 +1,20 @@
+<!--
+     Copyright (C) 2018 CandyRoms
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources>
+    <!-- Full screen aspect ratio -->
+    <bool name="config_haveHigherAspectRatioScreen">false</bool>
+    <item name="config_screenAspectRatio" format="float" type="dimen">2.1</item>
+</resources>

--- a/core/res/res/values/candy_symbols.xml
+++ b/core/res/res/values/candy_symbols.xml
@@ -61,4 +61,7 @@
   <java-symbol type="color" name="analog_clock_hand_hour_color" />
   <java-symbol type="color" name="analog_clock_hand_minute_color" />
 
+  <!-- Full screen aspect ratio -->
+  <java-symbol type="bool" name="config_haveHigherAspectRatioScreen" />
+  <java-symbol type="dimen" name="config_screenAspectRatio" />
 </resources>

--- a/services/core/java/com/android/server/am/ActivityRecord.java
+++ b/services/core/java/com/android/server/am/ActivityRecord.java
@@ -131,6 +131,7 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.ApplicationInfo;
 import android.content.res.CompatibilityInfo;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.GraphicBuffer;
 import android.graphics.Rect;
@@ -347,6 +348,10 @@ final class ActivityRecord extends ConfigurationContainer implements AppWindowCo
 
     private boolean mShowWhenLocked;
     private boolean mTurnScreenOn;
+
+    // Full screen aspect ratio
+    private final float mFullScreenAspectRatio = Resources.getSystem().getFloat(
+                    com.android.internal.R.dimen.config_screenAspectRatio);
 
     /**
      * Temp configs used in {@link #ensureActivityConfigurationLocked(int, boolean)}
@@ -2284,7 +2289,9 @@ final class ActivityRecord extends ConfigurationContainer implements AppWindowCo
     // TODO(b/36505427): Consider moving this method and similar ones to ConfigurationContainer.
     private void computeBounds(Rect outBounds) {
         outBounds.setEmpty();
-        final float maxAspectRatio = info.maxAspectRatio;
+        final boolean higherAspectRatio = Resources.getSystem().getBoolean(
+                com.android.internal.R.bool.config_haveHigherAspectRatioScreen);
+        final float maxAspectRatio = higherAspectRatio ? mFullScreenAspectRatio : info.maxAspectRatio;
         final ActivityStack stack = getStack();
         if (task == null || stack == null || !task.mFullscreen || maxAspectRatio == 0
                 || isInVrUiMode(getConfiguration())) {


### PR DESCRIPTION
When an app target pre-O releases, the default max aspect ratio
is 1.86:1 which leads to ugly black areas on devices that have
screens with higher aspect ratio (for example Galaxy S8/S9).

This change adds an option to allow users to change default
aspect ratio for pre-O apps to 2.1 which would fit recent devices.

@wight554
Simplify the code, we don't need the Settings for that, just bool

Change-Id: I88035fb079bad9a66b36fe5e861017af568b8f4c
Signed-off-by: bablusss <baaswanthmadhav@gmail.com>